### PR TITLE
refactor(GroupController): return redirect to dashboard as response i…

### DIFF
--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -2,9 +2,10 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Group;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
-use App\Models\Group;
+use Illuminate\Support\Facades\Redirect;
 
 class GroupController extends Controller
 {
@@ -61,7 +62,7 @@ class GroupController extends Controller
 
         $group->delete();
 
-        return back()->with('toast.success', 'Group has been deleted.');
+        return Redirect::route('dashboard')->with('toast.success', 'Group has been deleted.');
     }
 
     


### PR DESCRIPTION
Fix 404 Page Not Found error shown after deleting a group on its Show Group page (/todo/{group_id}) by redirecting the user to the dashboard page upon successful deletion in the GroupController destroy method.