### PR TITLE
fix: resolve broken button interactions after deleting a group

### DIFF
--- a/resources/js/components/group/group-item.jsx
+++ b/resources/js/components/group/group-item.jsx
@@ -1,7 +1,7 @@
 import { SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
 import { Link, router, usePage } from '@inertiajs/react';
 import { Hash, EllipsisVertical, Edit, Trash } from 'lucide-react';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import EditGroup from '@/components/group/edit-group'
 import {
     DropdownMenu,
@@ -21,19 +21,24 @@ import {
     AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
 import { preventNavigate } from '@/lib/utils';
+import { AlertDialogTrigger } from '@radix-ui/react-alert-dialog';
 
 
 const GroupItem = ({ item }) => {
     const page = usePage();
     const [enableEditGroup, setEnableEditGroup] = useState(false)
-    const [displayDeleteDialog, setDisplayDeleteDialog] = useState(false)
+    const deleteDialogTrigger = useRef()
 
     const handleEditIconClick = (e) => {
         setEnableEditGroup(true)
     }
 
     const handleDeleteItem = () => {
-        router.delete(route('group.destroy', item.id))
+        setDisplayDeleteDialog(false)
+
+        setTimeout(() => {
+            router.delete(route('group.destroy', item.id))
+        }, 1000);
     }
 
     return (
@@ -80,7 +85,7 @@ const GroupItem = ({ item }) => {
                                         onClick={(e) => {
                                             preventNavigate(e)
                                             setTimeout(() => {
-                                                setDisplayDeleteDialog(true)
+                                                deleteDialogTrigger?.current.click()
                                             }, 200);
                                         }}
                                     >
@@ -94,7 +99,8 @@ const GroupItem = ({ item }) => {
             </SidebarMenuItem>
 
             {/* BEGIN: Deletation Alert Dialog */}
-            <AlertDialog open={displayDeleteDialog}>
+            <AlertDialog>
+                <AlertDialogTrigger ref={deleteDialogTrigger}/>
                 <AlertDialogContent>
                     <AlertDialogHeader>
                         <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
@@ -103,7 +109,7 @@ const GroupItem = ({ item }) => {
                         </AlertDialogDescription>
                     </AlertDialogHeader>
                     <AlertDialogFooter>
-                        <AlertDialogCancel className='cursor-pointer' onClick={() => setDisplayDeleteDialog(false)}>Cancel</AlertDialogCancel>
+                        <AlertDialogCancel className='cursor-pointer'>Cancel</AlertDialogCancel>
                         <AlertDialogAction className='cursor-pointer' onClick={handleDeleteItem}>Continue</AlertDialogAction>
                     </AlertDialogFooter>
                 </AlertDialogContent>

--- a/resources/js/components/ui/alert-dialog.tsx
+++ b/resources/js/components/ui/alert-dialog.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
 
-import { cn } from "@/lib/utils"
+import { cn, removeHtmlBodyNonePointerEventsStyle } from "@/lib/utils"
 import { buttonVariants } from "@/components/ui/button"
 
 function AlertDialog({
@@ -132,6 +132,8 @@ function AlertDialogCancel({
   className,
   ...props
 }: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+  removeHtmlBodyNonePointerEventsStyle()
+
   return (
     <AlertDialogPrimitive.Cancel
       className={cn(buttonVariants({ variant: "outline" }), className)}

--- a/resources/js/lib/utils.ts
+++ b/resources/js/lib/utils.ts
@@ -17,3 +17,8 @@ export function preventNavigate(e: MouseEvent | KeyboardEvent) {
     e.stopPropagation();
     e.preventDefault();
 }
+
+export function removeHtmlBodyNonePointerEventsStyle(){
+    const body = document.getElementsByTagName('body')[0]
+    body.style.pointerEvents = ''
+}


### PR DESCRIPTION
Issue:
After opening the delete confirmation dialog for a group item, the UI becomes unresponsive. Buttons stop working, forcing the user to refresh the entire page to recover functionality.

Fix:

    Remove body tag's pointer-events style after cllse the dialog