### PR TITLE
Fixed: Group Deletion Confirmation Not Working

### DIFF
--- a/resources/js/components/group/group-item.jsx
+++ b/resources/js/components/group/group-item.jsx
@@ -27,7 +27,7 @@ import { AlertDialogTrigger } from '@radix-ui/react-alert-dialog';
 const GroupItem = ({ item }) => {
     const page = usePage();
     const [enableEditGroup, setEnableEditGroup] = useState(false)
-    const deleteDialogTrigger = useRef()
+    const deleteDialogTriggerRef = useRef()
 
     const handleEditIconClick = (e) => {
         setEnableEditGroup(true)
@@ -85,7 +85,7 @@ const GroupItem = ({ item }) => {
                                         onClick={(e) => {
                                             preventNavigate(e)
                                             setTimeout(() => {
-                                                deleteDialogTrigger?.current.click()
+                                                deleteDialogTriggerRef?.current.click()
                                             }, 200);
                                         }}
                                     >
@@ -100,7 +100,7 @@ const GroupItem = ({ item }) => {
 
             {/* BEGIN: Deletation Alert Dialog */}
             <AlertDialog>
-                <AlertDialogTrigger ref={deleteDialogTrigger}/>
+                <AlertDialogTrigger ref={deleteDialogTriggerRef}/>
                 <AlertDialogContent>
                     <AlertDialogHeader>
                         <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>

--- a/resources/js/components/group/group-item.jsx
+++ b/resources/js/components/group/group-item.jsx
@@ -28,7 +28,6 @@ const GroupItem = ({ item }) => {
     const page = usePage();
     const [enableEditGroup, setEnableEditGroup] = useState(false)
     const deleteDialogTriggerRef = useRef()
-    const closeDialogRef = useRef()
 
     const handleEditIconClick = (e) => {
         setEnableEditGroup(true)
@@ -106,7 +105,7 @@ const GroupItem = ({ item }) => {
                         </AlertDialogDescription>
                     </AlertDialogHeader>
                     <AlertDialogFooter>
-                        <AlertDialogCancel className='cursor-pointer' ref={closeDialogRef}>Cancel</AlertDialogCancel>
+                        <AlertDialogCancel className='cursor-pointer'>Cancel</AlertDialogCancel>
                         <AlertDialogAction className='cursor-pointer' onClick={handleDeleteItem}>Continue</AlertDialogAction>
                     </AlertDialogFooter>
                 </AlertDialogContent>

--- a/resources/js/components/group/group-item.jsx
+++ b/resources/js/components/group/group-item.jsx
@@ -28,6 +28,7 @@ const GroupItem = ({ item }) => {
     const page = usePage();
     const [enableEditGroup, setEnableEditGroup] = useState(false)
     const deleteDialogTriggerRef = useRef()
+    const closeDialogRef = useRef()
 
     const handleEditIconClick = (e) => {
         setEnableEditGroup(true)
@@ -109,7 +110,7 @@ const GroupItem = ({ item }) => {
                         </AlertDialogDescription>
                     </AlertDialogHeader>
                     <AlertDialogFooter>
-                        <AlertDialogCancel className='cursor-pointer'>Cancel</AlertDialogCancel>
+                        <AlertDialogCancel className='cursor-pointer' ref={closeDialogRef}>Cancel</AlertDialogCancel>
                         <AlertDialogAction className='cursor-pointer' onClick={handleDeleteItem}>Continue</AlertDialogAction>
                     </AlertDialogFooter>
                 </AlertDialogContent>

--- a/resources/js/components/group/group-item.jsx
+++ b/resources/js/components/group/group-item.jsx
@@ -35,8 +35,6 @@ const GroupItem = ({ item }) => {
     }
 
     const handleDeleteItem = () => {
-        setDisplayDeleteDialog(false)
-
         setTimeout(() => {
             router.delete(route('group.destroy', item.id))
         }, 1000);

--- a/resources/js/components/group/group-item.jsx
+++ b/resources/js/components/group/group-item.jsx
@@ -35,9 +35,7 @@ const GroupItem = ({ item }) => {
     }
 
     const handleDeleteItem = () => {
-        setTimeout(() => {
-            router.delete(route('group.destroy', item.id))
-        }, 1000);
+        router.delete(route('group.destroy', item.id))
     }
 
     return (
@@ -99,7 +97,7 @@ const GroupItem = ({ item }) => {
 
             {/* BEGIN: Deletation Alert Dialog */}
             <AlertDialog>
-                <AlertDialogTrigger ref={deleteDialogTriggerRef}/>
+                <AlertDialogTrigger ref={deleteDialogTriggerRef} />
                 <AlertDialogContent>
                     <AlertDialogHeader>
                         <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>


### PR DESCRIPTION
### Problem:
The delete group confirmation dialog was not properly executing deletions when confirmed. Users could click the confirmation button but the group would remain undeleted.

Root Cause:

    Invalid reference to non-existent setDisplayDeleteDialog function