### PR TITLE
feat: implement todo item deletion

### DIFF
--- a/app/Http/Controllers/TodoController.php
+++ b/app/Http/Controllers/TodoController.php
@@ -71,6 +71,8 @@ class TodoController extends Controller
      */
     public function destroy(Todo $todo)
     {
-        //
+        $todo->delete();
+
+        return back()->with('toast.success', 'Todo deleted successfully.');
     }
 }

--- a/resources/js/components/todo/delete-todo-confirmation-dialog.tsx
+++ b/resources/js/components/todo/delete-todo-confirmation-dialog.tsx
@@ -1,0 +1,40 @@
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+    AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
+import { useEffect, useRef } from "react";
+
+const DeleteTodoConfirmationDialog = ({ todo, onConfirm, onClose}) => {
+    const triggerRef = useRef(null)
+
+    useEffect(() => {
+        triggerRef.current.click()
+    }, [])
+
+    return (
+        <AlertDialog onOpenChange={(open) => !open ? onClose() : null}>
+            <AlertDialogTrigger ref={triggerRef} className="invisible  h-0">Open</AlertDialogTrigger>
+            <AlertDialogContent>
+                <AlertDialogHeader>
+                    <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+                    <AlertDialogDescription>
+                        Do you wanna to delete '{todo.title}' ?
+                    </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                    <AlertDialogCancel>Cancel</AlertDialogCancel>
+                    <AlertDialogAction onClick={() => onConfirm()}>Continue</AlertDialogAction>
+                </AlertDialogFooter>
+            </AlertDialogContent>
+        </AlertDialog>
+    )
+}
+
+export default DeleteTodoConfirmationDialog;

--- a/resources/js/pages/todo/todo-index.tsx
+++ b/resources/js/pages/todo/todo-index.tsx
@@ -1,6 +1,6 @@
 import AppLayout from '@/layouts/app-layout';
 import { type BreadcrumbItem } from '@/types';
-import { Head, usePage } from '@inertiajs/react';
+import { Head, router, usePage } from '@inertiajs/react';
 import {
     Table,
     TableBody,
@@ -17,12 +17,14 @@ import { Separator } from '@radix-ui/react-separator';
 import { useState } from 'react';
 import CreateTodoDialog from '@/components/todo/create-todo-dialog'
 import TodoDetailDialog from './todo-detail-dialog';
+import DeleteTodoConfirmationDialog from '@/components/todo/delete-todo-confirmation-dialog';
 
 
 const TodoIndex = () => {
     const { group, todos } = usePage().props
     const [showCreateDialog, setShowCreateDialog] = useState(false)
     const [showTodoDetail, setShowTodoDetail] = useState(false)
+    const [todoToDelete, setTodoToDelete] = useState(null)
 
     const breadcrumbs: BreadcrumbItem[] = [
         {
@@ -38,8 +40,10 @@ const TodoIndex = () => {
             {/* CREATE NEW TODO DIALOG */}
             <CreateTodoDialog open={showCreateDialog} setOpen={setShowCreateDialog} groupId={group.id} />
 
+            {todoToDelete ? <DeleteTodoConfirmationDialog todo={todoToDelete} onConfirm={() => router.delete(route('todo.delete', todoToDelete.id))} onClose={() => setTodoToDelete(null)}/> : null}
+
             {/* SHOW TODO DETAIL DIALOG  */}
-            {showTodoDetail ? (<TodoDetailDialog todo={showTodoDetail} onClose={() => setShowTodoDetail(null)}/>) : null}
+            {showTodoDetail ? (<TodoDetailDialog todo={showTodoDetail} onClose={() => setShowTodoDetail(null)} />) : null}
 
             {/* TODOS TABLE */}
             <div className="flex h-full flex-1 flex-col gap-4 rounded-xl p-4 overflow-x-auto">
@@ -74,7 +78,7 @@ const TodoIndex = () => {
                                     <TableCell className="truncate max-w-[400px]">{item.description}</TableCell>
                                     <TableCell>{dateFnsFormat(item.created_at, 'PPpp')}</TableCell>
                                     <TableCell>
-                                        <Button size={'sm'} variant={'link'} className='text-red-400 cursor-pointer'>Delete</Button>
+                                        <Button size={'sm'} variant={'link'} className='text-red-400 cursor-pointer' onClick={() => setTodoToDelete(item)}>Delete</Button>
                                     </TableCell>
                                 </TableRow>
                             ))

--- a/resources/js/pages/todo/todo-index.tsx
+++ b/resources/js/pages/todo/todo-index.tsx
@@ -63,6 +63,7 @@ const TodoIndex = () => {
                             <TableHead className="w-[100px]">Title</TableHead>
                             <TableHead>Description</TableHead>
                             <TableHead>Created At</TableHead>
+                            <TableHead>Actions</TableHead>
                         </TableRow>
                     </TableHeader>
                     <TableBody>
@@ -72,6 +73,9 @@ const TodoIndex = () => {
                                     <TableCell className="font-medium truncate max-w-[200px] cursor-pointer" onClick={() => setShowTodoDetail(item)}>{item.title}</TableCell>
                                     <TableCell className="truncate max-w-[400px]">{item.description}</TableCell>
                                     <TableCell>{dateFnsFormat(item.created_at, 'PPpp')}</TableCell>
+                                    <TableCell>
+                                        <Button size={'sm'} variant={'link'} className='text-red-400 cursor-pointer'>Delete</Button>
+                                    </TableCell>
                                 </TableRow>
                             ))
                         }

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,6 +23,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
     Route::post('/todo', [TodoController::class, 'store'])->name('todo.store');
     Route::get('/{group}/todo', [TodoController::class, 'index'])->name('group.todo');
+    Route::delete('/todo/{todo}', [TodoController::class, 'destroy'])->name('todo.delete');
 });
 
 require __DIR__.'/settings.php';

--- a/tests/Feature/TodoControllerTest.php
+++ b/tests/Feature/TodoControllerTest.php
@@ -72,4 +72,20 @@ class TodoControllerTest extends TestCase
         $response->assertRedirect();
         $response->assertSessionHas('toast.success', 'Todo created successfully.');
     }
+
+    public function test_destroy_todo_deletes_todo_and_redirects_with_success_message()
+    {
+        $user = User::factory()->create();
+        $group = Group::factory()->for($user, 'owner')->create();
+        $todo = Todo::factory()->for($group)->create();
+        
+        $this->actingAs($user);
+
+        $response = $this->delete(route('todo.delete', $todo->id));
+
+        $this->assertDatabaseMissing('todos', ['id' => $todo->id]);
+
+        $response->assertRedirect();
+        $response->assertSessionHas('toast.success', 'Todo deleted successfully.');
+    }
 }


### PR DESCRIPTION
This PR adds the ability to delete a todo item from the list with a confirmation prompt to prevent accidental removals.

### Changes:
- Added delete button to each todo item
- Implemented confirmation dialog before deletion

### UX:
- A confirmation modal appears when the delete button is clicked
- Deletion updates the UI instantly and reflects in the persistent store
- Feedback is provided on success/failure (toast)
